### PR TITLE
Update list of required lnd ENV variables

### DIFF
--- a/src/app2/part0-1.md
+++ b/src/app2/part0-1.md
@@ -33,15 +33,19 @@ We'll again use the `dotenv` package to simplify environment variables.
 You'll need to add some values to the `.env` inside the `server` sub-project. Specifically we'll set values for the following:
 
 - `LND_RPC_HOST` is the host for LND RPC
-- `LND_HOST` is the host for LND RPC
 - `LND_ADMIN_MACAROON_PATH` is the file path to the admin Macaroon
+- `LND_INVOICE_MACAROON_PATH` is the file path to the invoice Macaroon
+- `LND_READONLY_MACAROON_PATH` is the file path to the "readonly" Macaroon
 - `LND_CERT_PATH` is the certificate we use to securely connect with LND
+
+Optionally, you can also set the `LND_REST_HOST` value.
+It's not necessary for this tutorial, but if you want to experiment with the REST API via the `building-lightning-invoices` repo, you will need it.
 
 To populate these values navigate to Polar. To access Alice's node by clicking on Alice and then click on the `Connect` tab. You will be shown the information on how to connect to the GRPC and REST interfaces. Additionally you will be given paths to the network certificates and macaroon files that we will need in `.env`.
 
 ![Connect to Alice](../images/ch1_polar_connect_to_alice.png)
 
-Go ahead and add the three environment variables defined above to `.env`.
+Go ahead and add the environment variables defined above to `.env`.
 
 ```
 # Express configuration
@@ -49,7 +53,10 @@ PORT=8001
 
 # LND configuration
 # Exercise: Provide values for Alice's node
+LND_REST_HOST=
 LND_RPC_HOST=
-LND_ADMIN_MACAROON_PATH=
 LND_CERT_PATH=
+LND_ADMIN_MACAROON_PATH=
+LND_INVOICE_MACAROON_PATH=
+LND_READONLY_MACAROON_PATH=
 ```


### PR DESCRIPTION
There's a few things going on here.
I'm afraid I have more questions than fixes with this PR. 😄 

First,
> You'll need to add some values to the `.env` inside the `server` sub-project.

but, there is no `.env` file in the `server` sub-project. [link](https://github.com/bmancini55/building-lightning-invoices/tree/main/server).

So, I created one and added the env values specified in the walkthrough:
- `LND_RPC_HOST`
- `LND_ADMIN_MACAROON_PATH`
- `LND_CERT_PATH`

But when I tried to run the `npm run script:create-invoice`, I got an error
> TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received undefined

The stacktrace led me to `server/src/Options.ts` where I see it's trying to read [`LND_INVOICE_MACAROON_PATH`](https://github.com/bmancini55/building-lightning-invoices/blob/689c6696e7d6ea0ae15591eeb16622c9de0e0c2d/server/src/Options.ts#L18) and [`LND_READONLY_MACAROON_PATH`](https://github.com/bmancini55/building-lightning-invoices/blob/689c6696e7d6ea0ae15591eeb16622c9de0e0c2d/server/src/Options.ts#L19), which were not specified in the instructions (hence this PR).

I also noticed that `server/src/Options.ts` also sets [`PORT`](https://github.com/bmancini55/building-lightning-invoices/blob/689c6696e7d6ea0ae15591eeb16622c9de0e0c2d/server/src/Options.ts#L13) and [`LND_REST_HOST`](https://github.com/bmancini55/building-lightning-invoices/blob/689c6696e7d6ea0ae15591eeb16622c9de0e0c2d/server/src/Options.ts#L14) 
(note that `LND_REST_HOST` is called [`LND_HOST` in `building-lightning-graph`](https://github.com/bmancini55/building-lightning-graph/blob/b7a692c1ed5ea524fa8b0a397b51204ef1f17cfa/server/.env#L6))

In summary, my outstanding questions:
- Should `.env` already exist?
- Should `LND_REST_HOST` be called `LND_REST_HOST` or `LND_HOST`?
- Are `LND_REST_HOST` and `PORT` necessary at all?  (I'm not done with the walkthrough yet)
